### PR TITLE
v0.1.1 rev, fixes upstream #6

### DIFF
--- a/scanworker/endor_scanworker/cli.py
+++ b/scanworker/endor_scanworker/cli.py
@@ -44,7 +44,11 @@ def process_args():
     parser.add_argument('--gh', type=Path, default='./gh')
     parser.add_argument('--endorctl', type=Path, default='./endorctl')
     parser.add_argument('--results', type=Path)
-    parser.add_argument('--debug', action='store_true', default=os.getenv('ENDOR_DEBUG', False))
+    
+    # hidden configs
+    parser.add_argument('--debug', action='store_true', default=os.getenv('ENDOR_DEBUG', False), help=argparse.SUPPRESS)
+    parser.add_argument('--scm', default='github', help=argparse.SUPPRESS)
+
 
     args = parser.parse_args()
     args.lang = languages if args.lang is None else args.lang
@@ -123,12 +127,16 @@ def _main():
             sdterr(f"Skipping {project['nameWithOwner']} because I've already seen it")
             continue
 
+        scan_options = {}
+        if config.scm == 'github':
+            scan_options['enable'] = 'github,git,analytics'
+
         seen_project[project['url']] = True
         try:
             stderr(f"Clone {project['nameWithOwner']}")
             gh.clone(project['nameWithOwner'])
             stderr(f"-> SCANNING {project['name']}")
-            results = ec.scan(path=project['name'])
+            results = ec.scan(path=project['name'], **scan_options)
 
             file_base = f"{project['nameWithOwner'].replace('/','_')}"
         

--- a/scanworker/pyproject.toml
+++ b/scanworker/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "endor_scanworker"
 description = "Endor Labs secretless scan worker manager"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     { name = "Darren Meyer (Endor Labs)", email = "darren@endor.ai" }
 ]


### PR DESCRIPTION
Adds default enable of `github` analysis action on scans of GitHub repos; this enriches Endor Labs platform data with GitHub metadata